### PR TITLE
Add Remote Data Layer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/iesam/superheroes23/features/data/ApiClient.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/ApiClient.kt
@@ -1,0 +1,61 @@
+package com.iesam.superheroes23.features.data
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.app.left
+import com.iesam.superheroes23.app.right
+import com.iesam.superheroes23.features.data.biograpphy.remote.api.BiographyApiModel
+import com.iesam.superheroes23.features.data.superHero.remote.api.SuperHeroApiModel
+import com.iesam.superheroes23.features.data.work.remote.api.WorkApiModel
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class ApiClient  {
+    val baseUrl :String = "https://dam.sitehub.es/api-curso/superheroes/"
+
+    private val apiServices: ApiService
+
+    init {
+        apiServices = buildApiEndPoints()
+    }
+
+    fun createRotrofitClient() =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+    fun buildApiEndPoints() = createRotrofitClient().create(ApiService::class.java)
+
+    suspend fun getAllHeroes():Either<ErrorApp,List<SuperHeroApiModel>?>{
+        val heroes = apiServices.getAllHeroes()
+
+        if(heroes.isSuccessful){
+            return heroes.body().right()
+        }else{
+            return ErrorApp.InternetError.left()
+        }
+
+    }
+
+    suspend fun getWork(heroId:Int):Either<ErrorApp,WorkApiModel?>{
+        val work = apiServices.getWork(heroId)
+         if(work.isSuccessful){
+             return work.body().right()
+        }else{
+            return ErrorApp.InternetError.left()
+        }
+    }
+
+    suspend fun getBiography(heroId:Int):Either<ErrorApp,BiographyApiModel?>{
+        val biography = apiServices.getBiography(heroId)
+        if(biography.isSuccessful){
+            return biography.body().right()
+        }else{
+            return ErrorApp.InternetError.left()
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/ApiService.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/ApiService.kt
@@ -1,0 +1,20 @@
+package com.iesam.superheroes23.features.data
+
+import com.iesam.superheroes23.features.data.biograpphy.remote.api.BiographyApiModel
+import com.iesam.superheroes23.features.data.superHero.remote.api.SuperHeroApiModel
+import com.iesam.superheroes23.features.data.work.remote.api.WorkApiModel
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ApiService {
+
+    @GET("work/{heroId}.json")
+    suspend fun getWork(@Path("heroId") heroId:Int) : Response<WorkApiModel>
+
+    @GET("heroes.json")
+    suspend fun getAllHeroes() : Response<List<SuperHeroApiModel>>
+
+    @GET("biography/{heroId}.json")
+    suspend fun getBiography(@Path("heroId") heroId:Int) : Response<BiographyApiModel>
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/BiographyDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/BiographyDataRepository.kt
@@ -1,0 +1,15 @@
+package com.iesam.superheroes23.features.data.biograpphy
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.data.biograpphy.remote.api.BiographyRemoteApiSource
+import com.iesam.superheroes23.features.domain.Biography
+import com.iesam.superheroes23.features.domain.BiographyRepository
+
+class BiographyDataRepository(
+    private val remoteSource: BiographyRemoteApiSource
+) : BiographyRepository {
+    override suspend fun getBiographyByHeroId(heroId: Int): Either<ErrorApp, Biography?> {
+        return remoteSource.getBiography(heroId)
+    }
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/BiographyRemoteDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/BiographyRemoteDataRepository.kt
@@ -1,0 +1,10 @@
+package com.iesam.superheroes23.features.data.biograpphy.remote
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.domain.Biography
+
+interface BiographyRemoteDataRepository {
+
+    suspend fun getBiography(heroId : Int): Either<ErrorApp,Biography?>
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyApiMapper.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyApiMapper.kt
@@ -1,0 +1,10 @@
+package com.iesam.superheroes23.features.data.biograpphy.remote.api
+
+import com.iesam.superheroes23.features.domain.Biography
+
+fun BiographyApiModel.toDomain():Biography {
+    return Biography(
+        this.realName,
+        this.aligment
+    )
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyApiModel.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyApiModel.kt
@@ -1,0 +1,8 @@
+package com.iesam.superheroes23.features.data.biograpphy.remote.api
+
+import com.google.gson.annotations.SerializedName
+
+data class BiographyApiModel (
+    @SerializedName("fullName")  val realName:String,
+    @SerializedName("alignment")  val aligment:String
+)

--- a/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyRemoteApiSource.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/biograpphy/remote/api/BiographyRemoteApiSource.kt
@@ -1,0 +1,26 @@
+package com.iesam.superheroes23.features.data.biograpphy.remote.api
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.app.left
+import com.iesam.superheroes23.app.right
+import com.iesam.superheroes23.features.data.ApiClient
+import com.iesam.superheroes23.features.data.ApiService
+import com.iesam.superheroes23.features.data.biograpphy.remote.BiographyRemoteDataRepository
+import com.iesam.superheroes23.features.domain.Biography
+
+class BiographyRemoteApiSource(
+    private val apiClient: ApiClient
+) : BiographyRemoteDataRepository {
+    override suspend fun getBiography(heroId: Int): Either<ErrorApp, Biography?> {
+        return if(apiClient.getBiography(heroId).isRight()){
+            apiClient
+                .getBiography(heroId)
+                .get()
+                ?.toDomain()
+                .right()
+        }else{
+            ErrorApp.InternetError.left()
+        }
+    }
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/superHero/SuperHeroDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/superHero/SuperHeroDataRepository.kt
@@ -1,0 +1,19 @@
+package com.iesam.superheroes23.features.data.superHero
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.data.superHero.remote.api.SuperHeroesRemoteApiSource
+import com.iesam.superheroes23.features.domain.SuperHero
+import com.iesam.superheroes23.features.domain.SuperHeroRepository
+
+class SuperHeroDataRepository(
+    private val remoteSource: SuperHeroesRemoteApiSource
+) : SuperHeroRepository {
+    override suspend fun getAllHeroes(): Either<ErrorApp, List<SuperHero>?> {
+        return  remoteSource.getAllHeroes()
+    }
+
+    override fun getHeroById(HeroId: Int): Either<ErrorApp, SuperHero> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/SuperHeroRemoteDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/SuperHeroRemoteDataRepository.kt
@@ -1,0 +1,10 @@
+package com.iesam.superheroes23.features.data.superHero.remote
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.domain.SuperHero
+
+interface SuperHeroRemoteDataRepository {
+
+    suspend fun getAllHeroes(): Either<ErrorApp,List<SuperHero>?>
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroApiMapper.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroApiMapper.kt
@@ -1,0 +1,14 @@
+package com.iesam.superheroes23.features.data.superHero.remote.api
+
+import com.iesam.superheroes23.features.domain.SuperHero
+
+fun SuperHeroApiModel.toDomain():SuperHero {
+    return SuperHero(
+        this.id,
+        this.name,
+        listOf(
+            this.images.xs, this.images.sm, this.images.md, this.images.lg
+        )
+    )
+
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroApiModel.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroApiModel.kt
@@ -1,0 +1,13 @@
+package com.iesam.superheroes23.features.data.superHero.remote.api
+
+import com.google.gson.annotations.SerializedName
+
+data class SuperHeroApiModel (
+    @SerializedName("id") val id:Int,
+    @SerializedName("name") val name:String,
+    @SerializedName("images") val images: Images)
+data class Images(
+    @SerializedName("xs") val xs: String,
+    @SerializedName("sm") val sm: String,
+    @SerializedName("md") val md: String,
+    @SerializedName("lg") val lg: String)

--- a/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroesRemoteApiSource.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/superHero/remote/api/SuperHeroesRemoteApiSource.kt
@@ -1,0 +1,25 @@
+package com.iesam.superheroes23.features.data.superHero.remote.api
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.app.left
+import com.iesam.superheroes23.app.right
+import com.iesam.superheroes23.features.data.ApiClient
+import com.iesam.superheroes23.features.data.ApiService
+import com.iesam.superheroes23.features.data.superHero.remote.SuperHeroRemoteDataRepository
+import com.iesam.superheroes23.features.domain.SuperHero
+
+class SuperHeroesRemoteApiSource(
+    private val apiClient: ApiClient
+) : SuperHeroRemoteDataRepository {
+    override suspend fun getAllHeroes(): Either<ErrorApp, List<SuperHero>?> {
+        if(apiClient.getAllHeroes().isRight()){
+            val heros = apiClient.getAllHeroes().get()?.map { superHero->
+                superHero.toDomain()
+            }
+            return heros.right()
+        }else{
+            return ErrorApp.InternetError.left()
+        }
+    }
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/work/WorkDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/work/WorkDataRepository.kt
@@ -1,0 +1,15 @@
+package com.iesam.superheroes23.features.data.work
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.data.work.remote.WorkRemoteDataRepository
+import com.iesam.superheroes23.features.domain.Work
+import com.iesam.superheroes23.features.domain.WorkRepository
+
+class WorkDataRepository(
+    private val remoteSource:WorkRemoteDataRepository
+) : WorkRepository {
+    override suspend fun getWorkByHeroId(heroId: Int): Either<ErrorApp, Work?> {
+        return remoteSource.getWork(heroId)
+    }
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/WorkRemoteDataRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/WorkRemoteDataRepository.kt
@@ -1,0 +1,9 @@
+package com.iesam.superheroes23.features.data.work.remote
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.features.domain.Work
+
+interface WorkRemoteDataRepository {
+    suspend fun getWork(superHeroId: Int): Either<ErrorApp, Work?>
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkApiMapper.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkApiMapper.kt
@@ -1,0 +1,9 @@
+package com.iesam.superheroes23.features.data.work.remote.api
+
+import com.iesam.superheroes23.features.domain.Work
+
+fun WorkApiModel.toDomain() : Work{
+    return Work(
+        this.occupation,
+    )
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkApiModel.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkApiModel.kt
@@ -1,0 +1,7 @@
+package com.iesam.superheroes23.features.data.work.remote.api
+
+import com.google.gson.annotations.SerializedName
+
+data class WorkApiModel (
+    @SerializedName("occupation") val occupation:String
+)

--- a/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkRemoteApiSource.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/data/work/remote/api/WorkRemoteApiSource.kt
@@ -1,0 +1,24 @@
+package com.iesam.superheroes23.features.data.work.remote.api
+
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.app.left
+import com.iesam.superheroes23.app.right
+import com.iesam.superheroes23.features.data.ApiClient
+import com.iesam.superheroes23.features.data.ApiService
+import com.iesam.superheroes23.features.data.work.remote.WorkRemoteDataRepository
+import com.iesam.superheroes23.features.domain.Work
+
+class WorkRemoteApiDataSource(
+    private val apiClient: ApiClient
+) : WorkRemoteDataRepository {
+    override suspend fun getWork(superHeroId: Int): Either<ErrorApp, Work?> {
+        if(apiClient.getWork(superHeroId).isRight()){
+            return apiClient.getWork(superHeroId).get()?.toDomain().right()
+
+        }else{
+            return ErrorApp.InternetError.left()
+        }
+    }
+
+}

--- a/app/src/main/java/com/iesam/superheroes23/features/domain/BiographyRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/domain/BiographyRepository.kt
@@ -5,5 +5,5 @@ import com.iesam.superheroes23.app.ErrorApp
 
 interface BiographyRepository {
 
-    fun getBiographyByHeroId(heroId:Int):Either<ErrorApp,Biography>
+    suspend fun getBiographyByHeroId(heroId:Int):Either<ErrorApp,Biography?>
 }

--- a/app/src/main/java/com/iesam/superheroes23/features/domain/GetSuperHeroesFeedUseCase.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/domain/GetSuperHeroesFeedUseCase.kt
@@ -1,25 +1,29 @@
 package com.iesam.superheroes23.features.domain
 
+import com.iesam.superheroes23.app.Either
+import com.iesam.superheroes23.app.ErrorApp
+import com.iesam.superheroes23.app.right
+
 class GetSuperHeroesFeedUseCase(
     private val hero: SuperHeroRepository,
     private val work : WorkRepository,
     private val biography: BiographyRepository
 ) {
-    suspend fun execute() : List<SuperHeroList>{
+    suspend fun execute() : Either<ErrorApp,List<SuperHeroList>? > {
         val heros  = hero.getAllHeroes()
 
-        val list = heros.get().map {superHeroe ->
+        val list = heros.get()?.map { superHeroe ->
             val work = work.getWorkByHeroId(superHeroe.id)
             val biography = biography.getBiographyByHeroId(superHeroe.id)
             SuperHeroList(
                 superHeroe.id,
                 superHeroe.name,
-                biography.get().realName,
-                work.get().occupation,
+                biography.get()!!.realName,
+                work.get()!!.occupation,
                 superHeroe.getUrlImageS()
             )
         }
-        return list
+        return list.right()
     }
 
     data class SuperHeroList(

--- a/app/src/main/java/com/iesam/superheroes23/features/domain/SuperHeroRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/domain/SuperHeroRepository.kt
@@ -5,7 +5,7 @@ import com.iesam.superheroes23.app.ErrorApp
 
 interface SuperHeroRepository {
 
-    fun getAllHeroes():Either<ErrorApp,List<SuperHero>>
+    suspend fun getAllHeroes():Either<ErrorApp,List<SuperHero>?>
 
     fun getHeroById(HeroId:Int): Either<ErrorApp,SuperHero>
 }

--- a/app/src/main/java/com/iesam/superheroes23/features/domain/WorkRepository.kt
+++ b/app/src/main/java/com/iesam/superheroes23/features/domain/WorkRepository.kt
@@ -5,5 +5,5 @@ import com.iesam.superheroes23.app.ErrorApp
 
 interface WorkRepository {
 
-    fun getWorkByHeroId(heroId:Int):Either<ErrorApp,Work>
+    suspend fun getWorkByHeroId(heroId:Int):Either<ErrorApp,Work?>
 }


### PR DESCRIPTION
## Description de la tarea

Remote data obtain is implemented.

## ¿Cómo se ha implementado?

A data layer is created for each repository in the domain.
In each one a data remote source is created, in this case is retrofit (Api Source), I create a common apiService and ApiClient because they use the same endPoint, the apiService have the remote call to obtain data, and the client have the functions to change the apimodel to domain model.
For each one I create an apiModel that is the model of the remote data, an apiMapper that have the function to change the apimodel obtained to a domain model which is the one that will use the app and a remoteApiSource that call the functions to obtain the data and the function to changet it to domain and returns the necesary data

## Keywords

- ApiService
- ApiClient
- EndPoints
- Path
- Response
- ApiModel
- ApiMapper

## Screenshots or Video

Code to try the data obtaining:

![image](https://github.com/albertoh8/SuperHeroes23/assets/104196841/3a66de12-fc18-4879-8d80-e671a6dbffcc)

Logcat:

![image](https://github.com/albertoh8/SuperHeroes23/assets/104196841/981cbe89-3c27-4a71-aeef-06957dc20952)
